### PR TITLE
Fix case sensitivity of library variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,6 @@ julia> code, lib = compile_lib(c"""
        """)
 (CCode("int increment(int i) {\n  return i + 1;\n}\n"), "/tmp/jl_cfdpYw/lib.so")
 
-julia> ccall((:increment, LIB), Int, (Int,), 1)
+julia> ccall((:increment, lib), Int, (Int,), 1)
 2
 ```


### PR DESCRIPTION
compile_lib example is case sensitive so I made LIB->lib the same case.